### PR TITLE
Tweak sphere rew

### DIFF
--- a/assets/mjcf/simple_book.xml
+++ b/assets/mjcf/simple_book.xml
@@ -1,0 +1,22 @@
+<mujoco model="book">
+    <!-- A5 size book -->
+    <option timestep="0.002" gravity="0 0 -9.81" collision="predefined"/>
+    <default>
+        <joint type="hinge" pos="0 -0.2 0.007" axis="0 1 0" limited="true" damping="0.0 1"/>
+        <geom rgba="0.8 0.2 .2 1"/>
+    </default>
+    <worldbody>
+        <body name="simple_book">
+            <geom name="spine" type="cylinder" size="0.01" fromto="-0.074 -0.1049 0 -0.074 0.1049 0"/>
+            <geom name="pages" type="box" size="0.07 0.105 0.008" rgba="1 1 1 1"/>
+            <body name="front_cover">
+                <geom name="front_cover" type="box" size="0.074 0.105 0.002" pos="0 0 0.01"/>
+                <joint name="front_cover_joint" pos="-0.074 0 0" range="-150 0"/>
+            </body>
+            <body name="back_cover">
+                <geom name="back_cover" type="box" size="0.074 0.105 0.002" pos="0 0 -0.01"/>
+                <joint name="back_cover_joint" pos="-0.074 0 0" range="0 150"/>
+            </body>
+        </body>
+    </worldbody>
+</mujoco>

--- a/faive_gym/cfg/task/FaiveHandP0_book.yaml
+++ b/faive_gym/cfg/task/FaiveHandP0_book.yaml
@@ -1,0 +1,6 @@
+defaults:
+  - FaiveHandP0
+# a simple example of introducing an articulated object
+# doesn't learn any actual task, feel free to improve it...
+env:
+  object_type: ["simple_book"]

--- a/faive_gym/cfg/task/FaiveHandP0_crawl.yaml
+++ b/faive_gym/cfg/task/FaiveHandP0_crawl.yaml
@@ -1,0 +1,15 @@
+defaults:
+  - FaiveHandP0
+name: Crawl
+env:
+  hand_fix_base: False
+  hand_start_p: [0, 0, 0.1]
+  hand_start_r: [0, 0, 0, 1]
+
+rewards:
+  fall_dist_threshold: 10.  # practically disabled
+
+observations:
+  # change to include more stuff about body
+  actor_observations: ["dof_position", "dof_speed", "dof_pos_target", 
+                       "actions"]

--- a/faive_gym/cfg/task/FaiveHandP0_crawl.yaml
+++ b/faive_gym/cfg/task/FaiveHandP0_crawl.yaml
@@ -1,15 +1,40 @@
 defaults:
   - FaiveHandP0
+# use the Crawl class defined in tasks/crawl.py
+# see crawl.py for how to use
 name: Crawl
 env:
   hand_fix_base: False
   hand_start_p: [0, 0, 0.1]
   hand_start_r: [0, 0, 0, 1]
 
+  object_fix_base: True
+  object_start_offset: [0, 0, 1]  # move it to where it won't interfere with hand
+
 rewards:
+  scales:
+    action_penalty: 0.
+    dof_acc_penalty: 0.
+    dof_vel_penalty: 0.
+    dof_trq_penalty: -0.0025 
+    success: 0.
+    drop_penalty: 0.
+    simple_hand_flat: 0.0
+    
+    reorienttask_obj_dist: 0.
+    reorienttask_obj_rot: 0.
+
+    crawl_forward_vel: 20.
+    crawl_penalty_upsidedown: -0.1
+
   fall_dist_threshold: 10.  # practically disabled
 
 observations:
   # change to include more stuff about body
-  actor_observations: ["dof_position", "dof_speed", "dof_pos_target", 
+  actor_observations: ["dof_position", "dof_speed", "dof_force",
+                       "hand_quat", "hand_vel",
                        "actions"]
+                      
+  obs_dims:
+    hand_quat: 4
+    hand_vel: 6

--- a/faive_gym/cfg/task/FaiveHandP0_crawl.yaml
+++ b/faive_gym/cfg/task/FaiveHandP0_crawl.yaml
@@ -2,6 +2,7 @@ defaults:
   - FaiveHandP0
 # use the Crawl class defined in tasks/crawl.py
 # see crawl.py for how to use
+# doesn't actually train, just an example of how to have a free base robot
 name: Crawl
 env:
   hand_fix_base: False

--- a/faive_gym/cfg/task/RobotHandDefault.yaml
+++ b/faive_gym/cfg/task/RobotHandDefault.yaml
@@ -29,6 +29,10 @@ env:
   object_start_offset: [0, 0, 0]  # position of object initial position, relative to the hand
   actuated_dof_range_override: None  # optionally use a smaller joint range of actuation, helpful if the real robot can't achieve the full range of motion
 
+  # whether to fix objects in the world, or let them loose
+  object_fix_base: False
+  hand_fix_base: True
+
   # hand start pose position (x, y, z)
   hand_start_p: [0, 0, 0.5]
   # hand start pose quaternion (w, x, y, z)

--- a/faive_gym/cfg/task/RobotHandDefault.yaml
+++ b/faive_gym/cfg/task/RobotHandDefault.yaml
@@ -31,7 +31,8 @@ env:
 
   # hand start pose position (x, y, z)
   hand_start_p: [0, 0, 0.5]
-  # hand start pose quaternion (w, x, y, z)
+  # hand start pose quaternion (x, y, z, w)
+  # rotate 200 degrees around x axis to make palm face up, and slightly tilt it downwards
   hand_start_r: [0.9848078, 0, 0, -0.1736482]
 
 asset:

--- a/faive_gym/cfg/train/FaiveHandP0_bookPPO.yaml
+++ b/faive_gym/cfg/train/FaiveHandP0_bookPPO.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - FaiveHandP0PPO

--- a/faive_gym/cfg/train/FaiveHandP0_crawlPPO.yaml
+++ b/faive_gym/cfg/train/FaiveHandP0_crawlPPO.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - FaiveHandP0PPO

--- a/faive_gym/robot_hand.py
+++ b/faive_gym/robot_hand.py
@@ -1353,15 +1353,14 @@ class RobotHand(VecTask):
         This reward was used to generate the motions used in TEDx demo, but it may be more stable to set a goal object with that slowly rotates, like in "Circus ANYmal" paper
         """
         rotvel = self.object_angvel_numerical
-        # give max reward when rotvel is between -1 and -2
+        # give max reward when rotvel magnitude is larger than 1 rad/s
         # optionally flip this sign back to positive for the
         # ablation study
         direction = - self.cfg["env"]["x_rotation_dir"]
         a = direction * rotvel[:, 0] + 1
         b = torch.ones_like(a) * 2
-        c = rotvel[:, 0] + 4
-        # return the smallest of the three
-        return torch.min(torch.min(a, b), c)
+        # return the smallest of the two
+        return torch.min(a, b)
 
     # ------------- observation functions -----------------
     # the observation functions below may not be called depending on the

--- a/faive_gym/robot_hand.py
+++ b/faive_gym/robot_hand.py
@@ -139,11 +139,13 @@ class RobotHand(VecTask):
         )
     
         self.dof_force_tensor = gymtorch.wrap_tensor(dof_force_tensor).view(
-            self.num_envs, self.num_hand_dofs
+            self.num_envs, -1
         )
 
         # next, define new member variables that make it easier to access the state tensors
         # if arrays are not used for indexing, the sliced tensors will be views of the original tensors, and thus their values will be automatically updated
+        # Since it uses the first self.num_hand_dofs values of the dof state,
+        # this code assumes that the robot hand is the first thing that is loaded into IsaacGym with create_actor().
         self.hand_dof_state = self.dof_state.view(self.num_envs, -1, 2)[
             :, : self.num_hand_dofs
         ]
@@ -534,8 +536,8 @@ class RobotHand(VecTask):
             self.hand_dof_pos[env_ids] = dof_pos
             self.hand_dof_vel[env_ids] = dof_vel
             # TODO: may have to set nonactuated to 0
-            self.prev_targets[env_ids] = dof_pos
-            self.cur_targets[env_ids] = dof_pos
+            self.prev_targets[env_ids, :self.num_hand_dofs] = dof_pos
+            self.cur_targets[env_ids, :self.num_hand_dofs] = dof_pos
 
             hand_indices = self.hand_indices[env_ids].to(torch.int32)
             # set the dof targets in the sim

--- a/faive_gym/robot_hand.py
+++ b/faive_gym/robot_hand.py
@@ -575,7 +575,7 @@ class RobotHand(VecTask):
             # reset buffers
             self.progress_buf[env_ids] = 0
 
-        if len(goal_env_ids) or len(env_ids):
+        if len(reset_indices) > 0:
             # apparently this can only be called once per step?
             # will return False if command fails
             assert self.gym.set_actor_root_state_tensor_indexed(

--- a/faive_gym/robot_hand.py
+++ b/faive_gym/robot_hand.py
@@ -1072,7 +1072,6 @@ class RobotHand(VecTask):
                                         self.cfg['env']['hand_start_p'][2])
         object_start_pose = gymapi.Transform()
         object_start_pose.p = gymapi.Vec3()
-        # rotate 200 degrees around x axis to make palm face up, and slightly tilt it downwards
         hand_start_pose.r = gymapi.Quat(self.cfg['env']['hand_start_r'][0],
                                         self.cfg['env']['hand_start_r'][1],
                                         self.cfg['env']['hand_start_r'][2],

--- a/faive_gym/robot_hand.py
+++ b/faive_gym/robot_hand.py
@@ -555,25 +555,28 @@ class RobotHand(VecTask):
                 len(env_ids),
             )
 
-            # reset object position
-            object_states = self.object_init_states[env_ids].clone()
-            object_states[:, 0:3] += (
-                rand_floats[:, 0:3] * self.cfg["reset_noise"]["object_pos"]
-            )
-            # reset object rotation
-            object_states[:, 3:7] = randomize_rotation(
-                rand_floats[:, 3],
-                rand_floats[:, 4],
-                self.x_unit_tensor[env_ids],
-                self.y_unit_tensor[env_ids],
-            )
-            
-            # set the object state in the sim
-            self.root_state_tensor[self.object_indices[env_ids]] = object_states
+            # if object is fixed to the base, don't change its pose
+            if not self.cfg["env"]["object_fix_base"]:
+                # reset object position
+                object_states = self.object_init_states[env_ids].clone()
+                object_states[:, 0:3] += (
+                    rand_floats[:, 0:3] * self.cfg["reset_noise"]["object_pos"]
+                )
+                # reset object rotation
+                object_states[:, 3:7] = randomize_rotation(
+                    rand_floats[:, 3],
+                    rand_floats[:, 4],
+                    self.x_unit_tensor[env_ids],
+                    self.y_unit_tensor[env_ids],
+                )
+                
+                # set the object state in the sim
+                self.root_state_tensor[self.object_indices[env_ids]] = object_states
 
-            reset_indices = torch.cat(
-                (reset_indices, self.object_indices[env_ids].to(torch.int32))
-            )
+                reset_indices = torch.cat(
+                    (reset_indices, self.object_indices[env_ids].to(torch.int32))
+                )
+
             # reset buffers
             self.progress_buf[env_ids] = 0
 

--- a/faive_gym/robot_hand.py
+++ b/faive_gym/robot_hand.py
@@ -921,9 +921,9 @@ class RobotHand(VecTask):
         
         # load Faive Hand asset with these options
         asset_options = gymapi.AssetOptions()
-        asset_options.fix_base_link = True
+        asset_options.fix_base_link = self.cfg["env"]["hand_fix_base"]
         asset_options.collapse_fixed_joints = True
-        asset_options.disable_gravity = True
+        asset_options.disable_gravity = False  # TODO: check that this doesn't affect performance before PR merge!
         asset_options.thickness = 0.001
         asset_options.angular_damping = 0.01
         if self.physics_engine == gymapi.SIM_PHYSX:
@@ -1059,6 +1059,7 @@ class RobotHand(VecTask):
                     asset_files_dict[self.cfg["env"]["object_type"][i]]
                 )
             object_asset_options = gymapi.AssetOptions()
+            object_asset_options.fix_base_link = self.cfg["env"]["object_fix_base"]
             object_asset_list.append(self.gym.load_asset(
                 self.sim, asset_root, object_asset_file, object_asset_options
             ))

--- a/faive_gym/robot_hand.py
+++ b/faive_gym/robot_hand.py
@@ -1113,8 +1113,8 @@ class RobotHand(VecTask):
         goal_start_pose.p = object_start_pose.p + goal_visual_displacement
 
         # compute aggregate size
-        max_agg_bodies = self.num_hand_bodies + 2
-        max_agg_shapes = self.num_hand_shapes + 2
+        max_agg_bodies = self.num_hand_bodies + 2 * self.num_object_bodies
+        max_agg_shapes = self.num_hand_shapes + 2 * self.num_object_shapes
 
         self.envs = []
         hand_init_states = []

--- a/faive_gym/robot_hand.py
+++ b/faive_gym/robot_hand.py
@@ -1065,9 +1065,9 @@ class RobotHand(VecTask):
         # load manipulated object and goal assets
         object_asset_list = []
         goal_asset_list = []
-        for i in range(len(self.cfg["env"]["object_type"])):
+        for object_type in self.cfg["env"]["object_type"]:
             object_asset_file = os.path.normpath(
-                    asset_files_dict[self.cfg["env"]["object_type"][i]]
+                    asset_files_dict[object_type]
                 )
             object_asset_options = gymapi.AssetOptions()
             object_asset_options.fix_base_link = self.cfg["env"]["object_fix_base"]
@@ -1162,10 +1162,12 @@ class RobotHand(VecTask):
                 ])
 
             # add object, seg_id = 1
+            # randomly choose which object this environment will have
+            object_index = torch.randint(len(self.cfg["env"]["object_type"]), (1,)).item()
             object_handle = self.gym.create_actor(
-                env_ptr, object_asset_list[i%len(self.cfg["env"]["object_type"])], object_start_pose, "object", i, 0, 1
+                env_ptr, object_asset_list[object_index], object_start_pose, "object", i, 0, 1
             )
-            self.object_type[i][i%len(self.cfg["env"]["object_type"])] = 1
+            self.object_type[i][object_index] = 1
             object_init_states.append(
                 [
                     object_start_pose.p.x,
@@ -1188,7 +1190,7 @@ class RobotHand(VecTask):
             # by setting the fifth argument to not coincide with the others, the goal object does not collide with anything else
             goal_handle = self.gym.create_actor(
                 env_ptr,
-                goal_asset_list[i%len(self.cfg["env"]["object_type"])],
+                goal_asset_list[object_index],
                 goal_start_pose,
                 "goal_object",
                 i + self.num_envs,

--- a/faive_gym/robot_hand.py
+++ b/faive_gym/robot_hand.py
@@ -589,7 +589,7 @@ class RobotHand(VecTask):
                 reset_indices = torch.cat(
                     (reset_indices, self.object_indices[env_ids].to(torch.int32))
                 )
-             if not self.cfg["env"]["hand_fix_base"]:
+            if not self.cfg["env"]["hand_fix_base"]:
                 hand_states = self.hand_init_states[env_ids].clone()
                 # don't implement reset randomization for now...
                 self.root_state_tensor[self.hand_indices[env_ids]] = hand_states

--- a/faive_gym/robot_hand.py
+++ b/faive_gym/robot_hand.py
@@ -894,6 +894,7 @@ class RobotHand(VecTask):
             "stell_dodeca": "objects_dext_manip/stell_dodeca.urdf",
             "stairs": "objects_dext_manip/stairs.urdf",
             "block_pyr": "objects_dext_manip/block_pyr.urdf",
+            "simple_book": "mjcf/simple_book.xml",
         }
         for i in range(len(self.cfg["env"]["object_type"])):
             try:

--- a/faive_gym/tasks/crawl.py
+++ b/faive_gym/tasks/crawl.py
@@ -1,0 +1,11 @@
+from faive_gym.robot_hand import RobotHand
+
+"""
+The robot hand learns to crawl on the floor like a horror film.
+not a serious task, just intended as an example of
+- how to make a custom task that is derived from the RobotHand class
+- how to create environments where the robot hand doesn't have a fixed base
+"""
+
+class Crawl(RobotHand):
+    pass

--- a/faive_gym/tasks/crawl.py
+++ b/faive_gym/tasks/crawl.py
@@ -13,7 +13,7 @@ not a serious task, just intended as an example of
 - how to create environments where the robot hand doesn't have a fixed base
 
 The robot hand learns to crawl on the floor like a horror film - except it doesn't even learn to crawl right now, see if you can make it work...
-Before, running, manually delete the "base" mesh in the MJCF file, since the fingers won't even touch the ground that much with the base.
+Before running, manually delete the "base" mesh in the MJCF file, since the fingers won't even touch the ground that much with the base.
 """
 
 class Crawl(RobotHand):

--- a/faive_gym/tasks/crawl.py
+++ b/faive_gym/tasks/crawl.py
@@ -1,11 +1,56 @@
 from faive_gym.robot_hand import RobotHand
+from isaacgymenvs.utils.torch_jit_utils import (
+    quat_rotate_inverse,
+    quat_conjugate,
+    quat_mul,
+    quat_to_angle_axis,
+)
+import torch
 
 """
-The robot hand learns to crawl on the floor like a horror film.
 not a serious task, just intended as an example of
 - how to make a custom task that is derived from the RobotHand class
 - how to create environments where the robot hand doesn't have a fixed base
+
+The robot hand learns to crawl on the floor like a horror film - except it doesn't even learn to crawl right now, see if you can make it work...
+Before, running, manually delete the "base" mesh in the MJCF file, since the fingers won't even touch the ground that much with the base.
 """
 
 class Crawl(RobotHand):
-    pass
+
+    def check_termination(self):
+        # override the function defined in RobotHand
+        
+        # check if hand is upside down (z axis is facing up)
+        # do a bit hacky but easy to implement check
+        hand_rot = self.hand_pose[:, 3:]
+        angle, axis = quat_to_angle_axis(hand_rot)
+        self.upside_down_buf = (torch.norm(axis[:, :2], dim=1) > 0.9) & (angle > 0.8 * 3.14)
+
+        timeout_buf = self.progress_buf > self.max_episode_length - 1
+
+        self.reset_goal_buf[:] = 0
+        self.reset_buf[:] = self.upside_down_buf | timeout_buf
+
+ 
+    def _init_buffers(self):
+        super()._init_buffers()
+        # move forward (in the direction of the fingertip, which is the y axis) 10 cm/s
+        self.target_vel = torch.tensor([0., 0.07, -0.07], dtype=torch.float32, device=self.device)
+
+    def _reward_crawl_penalty_upsidedown(self):
+        return self.upside_down_buf
+
+    def _reward_crawl_forward_vel(self):
+        quat = self.hand_pose[:, 3:]
+        lin_vel = self.hand_vel[:, :3]
+        local_vel = quat_rotate_inverse(quat, lin_vel)
+        vel_error = torch.sum(torch.square(self.target_vel - local_vel), dim=1)
+        return torch.exp(-vel_error/0.05)
+
+    def _observation_hand_quat(self):
+        return self.hand_pose[:, 3:]
+    
+    def _observation_hand_vel(self):
+        return self.hand_vel
+    

--- a/faive_gym/train.py
+++ b/faive_gym/train.py
@@ -48,7 +48,9 @@ from isaacgymenvs.utils.utils import set_np_formatting, set_seed
 # register custom tasks for faive_gym here
 from isaacgymenvs.tasks import isaacgym_task_map
 from robot_hand import RobotHand
+from faive_gym.tasks.crawl import Crawl
 isaacgym_task_map["RobotHand"] = RobotHand
+isaacgym_task_map["Crawl"] = Crawl
 
 ## OmegaConf & Hydra Config
 


### PR DESCRIPTION
Note: merge only after I fix the todo in https://github.com/srl-ethz/faive_gym_oss/pull/4
The implementation of the sphere rotation reward had a “bug” in it… it’s a different shape based on the direction of rotation, when the direction is -1 it doesn’t decrease when the velocity magnitude is larger than 2 rad/s

Maybe that is why the -1 direction trained much better, thanks to this unintended bug, I’m retraining +1 direction with the same reward profile to see if it’s better

![IMG_1910](https://github.com/srl-ethz/faive_gym_oss/assets/16713520/06c409ac-255b-417f-8b26-a66fa9433e27)

This reward seems to work more consistently and use each finger equally for the +1 direction, than for the original reward (for the -1 direction, the implementation remains exactly the same

## checklist
PR can be merged after all these are met
- [x] describe the changes (with screenshots if it helps)
- [ ] If this PR modifies any part of the training, post the W&B results of the following experiments (post screenshot of the consecutive_successes)
    ```bash
    python train.py task=FaiveHandP0 capture_video=True force_render=False wandb_activate=True wandb_group=srl_ethz wandb_project=faive_hand wandb_name=faivehandp0_check
- [ ] compare with multiple random seeds if this is actually better
    ```