### PR TITLE
use 6D orientation representation

### DIFF
--- a/faive_gym/cfg/task/FaiveHandP0.yaml
+++ b/faive_gym/cfg/task/FaiveHandP0.yaml
@@ -23,13 +23,16 @@ observations:
     dof_force: 11
     obj_pos: 3
     obj_quat: 4
+    obj_rot: 6
     obj_linvel: 3
     obj_angvel: 3
     obj_linvel_numerical: 3
     obj_angvel_numerical: 3
     goal_pos: 3
     goal_quat: 4
+    goal_rot: 6
     goal_quat_diff: 4
+    goal_rot_diff: 6
     pose_sensor_pos: 15 # 3 * 5
     pose_sensor_quat: 20  # 4 * 5 
     pose_sensor_linvel: 15  # 3 * 5

--- a/faive_gym/cfg/task/RobotHandDefault.yaml
+++ b/faive_gym/cfg/task/RobotHandDefault.yaml
@@ -137,8 +137,8 @@ observations:
   # otherwise, the actor_observations is used for both actor and critic
   asymmetric_observations: False
   actor_observations: ["dof_position", "dof_speed", "dof_force",
-                       "obj_pos", "obj_quat", "obj_linvel", "obj_angvel",
-                       "goal_pos", "goal_quat", "goal_quat_diff",
+                       "obj_pos", "obj_rot", "obj_linvel", "obj_angvel",
+                       "goal_pos", "goal_rot", "goal_rot_diff",
                        "pose_sensor_pos", "pose_sensor_quat", "pose_sensor_linvel", "pose_sensor_angvel", "force_sensor_force",
                        "actions"]
 


### PR DESCRIPTION
since 6D rotation representations tend to perform better than quaternions...
https://arxiv.org/pdf/2404.11735
![image](https://github.com/srl-ethz/faive_gym_oss/assets/16713520/7c2859e3-43fe-48c4-b7eb-6c4d4ec8851f)

## checklist
PR can be merged after all these are met
- [x] describe the changes (with screenshots if it helps)
- [ ] If this PR modifies any part of the training, post the W&B results of the following experiments (post screenshot of the consecutive_successes)
    ```bash
    python train.py task=FaiveHandP0 capture_video=True force_render=False wandb_activate=True wandb_group=srl_ethz wandb_project=faive_hand wandb_name=faivehandp0_check
    ```