### PR TITLE
Fixed compatibility issues for MuJoCo >3.0 upgrade

### DIFF
--- a/assets/faive_hand_p0/faive_metadata.xml
+++ b/assets/faive_hand_p0/faive_metadata.xml
@@ -19,7 +19,6 @@ limitations under the License.
 
 <mujoco>
     <compiler angle="radian"/>
-    <option collision="all"/>
     <default>
         <!-- use same geom params as the Shadow Hand model in IsaacGymEnv for now -->
         <!-- the density is adjusted so that the total weight of the hand part (not including the base) is the same as the real hand (106g) (therefore the base will have a wrong mass, which shouldn't matter for now) -->

--- a/assets/mjcf/simple_book.xml
+++ b/assets/mjcf/simple_book.xml
@@ -1,9 +1,8 @@
 <mujoco model="book">
     <!-- A5 size book -->
-    <option timestep="0.002" gravity="0 0 -9.81" collision="predefined"/>
     <default>
-        <joint type="hinge" pos="0 -0.2 0.007" axis="0 1 0" limited="true" damping="0.0 1"/>
-        <geom rgba="0.8 0.2 .2 1"/>
+        <joint type="hinge" pos="0 -0.2 0.007" axis="0 1 0" limited="true" damping="0.01"/>
+        <geom contype="0" conaffinity="0" rgba="0.8 0.2 .2 1"/>
     </default>
     <worldbody>
         <body name="simple_book">


### PR DESCRIPTION
Followed the changelog recommendation to account for the removal of the `mjOption.collision` and the associated `option/collision` attribute.

Full Details from the CHANGELOG: https://mujoco.readthedocs.io/en/latest/changelog.html#id40

> Removed mjOption.collision and the associated option/collision attribute.
> Migration:
>    - For models which have `<option collision="all"/>`, delete the attribute.
>    - For models which have `<option collision="dynamic"/>`, delete all [pair](https://mujoco.readthedocs.io/en/latest/XMLreference.html#contact-pair) elements.
>    - For models which have `<option collision="predefined"/>`, disable all dynamic collisions (determined via contype/conaffinity) by first deleting all [contype](https://mujoco.readthedocs.io/en/latest/XMLreference.html#body-geom-contype) and [conaffinity](https://mujoco.readthedocs.io/en/latest/XMLreference.html#body-geom-conaffinity) attributes in the model and then setting them globally to 0 using <default> <geom contype="0" conaffinity="0"/> </default>.

## checklist
PR can be merged after all these are met
- [x] describe the changes (with screenshots if it helps): 
1. For the collision removal: Followed the recommendations above and loaded both the faive hand and the book within MuJoCo 3.2.3 viewer using `python -m mujoco.viewer`
2. Also noticed that the `damping` property of the joint in `simple_book.xml` should be a real number. I assume there was an erroneous space added so I've removed that too.
- [x] If this PR modifies any part of the training, post the W&B results of the following experiments (post screenshot of the consecutive_successes) **No changes here.**
    ```bash
    python train.py task=FaiveHandP0 capture_video=True force_render=False wandb_activate=True wandb_group=srl_ethz wandb_project=faive_hand wandb_name=faivehandp0_check
    ```